### PR TITLE
[Radical Red] Update data for 4.0

### DIFF
--- a/leagues/radred.txt
+++ b/leagues/radred.txt
@@ -282,35 +282,35 @@ naganadel|81|nasty-plot,sludge-wave,draco-meteor,flamethrower|beast-boost|life-o
 duraludon|81|draco-meteor,steel-beam,thunderbolt,dark-pulse|bad-company|duraludite
 
 --1r|Brock (Rematch)|rock|/leaders/frlg-brock
-gigalith|-2|stealth-rock,stone-edge,earthquake,explosion|sand-stream|smooth-rock
+great-tusk|-2|stealth-rock,close-combat,headlong-rush,knock-off|protosynthesis|booster-energy
+omastar|-2|shell-smash,meteor-beam,ice-beam,surf|weak-armor|power-herb
+sandslash|-2|rapid-spin,earthquake,stone-edge,x-scissor|sand-rush|soft-sand
 tyranitar|-2|stone-edge,fire-punch,crunch,dragon-dance|sand-stream|weakness-policy
-lycanroc-midday>lycanroc|-2|accelerock,stone-edge,close-combat,crunch|tough-claws|life-orb
-omastar|-2|shell-smash,meteor-beam,ice-beam,surf|battle-armor|power-herb
-sandslash|-2|swords-dance,earthquake,stone-edge,x-scissor|sand-rush|soft-sand
+arcanine-hisui|-2|flare-blitz,head-smash,wild-charge,extreme-speed|rock-head|focus-sash
 aerodactyl|-2|stone-edge,earthquake,dual-wingbeat,dragon-dance|tough-claws|aerodactylite
 
 --2r|Misty (Rematch)|water|/leaders/frlg-misty
-politoed|-2|scald,ice-beam,hypnosis,flip-turn|drizzle|damp-rock
-greninja|-2|dark-pulse,water-shuriken,ice-beam,grass-knot|protean|life-orb
-gorebyss|-2|shell-smash,surf,moonblast,ice-beam|regenerator|white-herb
-kingdra|-2|dragon-pulse,surf,hurricane,ice-beam|swift-swim|life-orb
-inteleon|-2|snipe-shot,dark-pulse,ice-beam,air-slash|sniper|scope-lens
+palafin|-2|flip-turn,wave-crash,jet-punch,drain-punch|zero-to-hero|mystic-water
+kingdra|-2|dragon-pulse,snipe-shot,hurricane,ice-beam|swift-swim|scope-lens
+seismitoad|-2|wave-crash,earthquake,power-whip,ice-punch|swift-swim|life-orb
 gyarados|-2|dragon-dance,waterfall,crunch,earthquake|mold-breaker|gyaradosite
+ferrothorn|-2|leech-seed,gyro-ball,power-whip,thunder-wave|iron-barbs|rocky-helmet
+gorebyss|-2|shell-smash,surf,moonblast,ice-beam|dazzling|focus-sash
 
 --3r|Lt. Surge (Rematch)|electric|/leaders/frlg-surge
-pachirisu|-2|reflect,light-screen,nuzzle,u-turn|prankster|light-clay
-dracozolt|-2|bolt-beak,dragon-claw,crunch,fire-fang|hustle|choice-scarf
-dedenne|-2|rising-voltage,volt-switch,dazzling-gleam,grass-knot|electric-surge|terrain-extender
-rotom-wash>rotom-wash|-2|nasty-plot,rising-voltage,hidden-power-grass,hydro-pump|levitate|life-orb
-rotom-mow>rotom-mow|-2|thunderbolt,leaf-storm,hidden-power-ice,nasty-plot|levitate|life-orb
+iron-treads|-2|earthquake,iron-head,stealth-rock,volt-switch|quark-drive|focus-sash
+bellibolt|-2|parabolic-charge,hidden-power-grass,muddy-water,volt-switch|electromorphosis|leftovers
+rotom-wash>rotom-wash|-2|volt-switch,rising-voltage,hidden-power-ice,scald|levitate|life-orb
+pawmot|-2|plasma-fists,close-combat,mach-punch,ice-punch|iron-fist|punching-glove
 manectric|-2|volt-switch,rising-voltage,flamethrower,hidden-power-grass|intimidate|manectite
+iron-hands|-2|plasma-fists,drain-punch,ice-punch,fake-out|quark-drive|assault-vest
 
 --4r|Erika (Rematch)|grass|/leaders/frlg-erika
-tsareena|-2|triple-axel,trop-kick,high-jump-kick,rapid-spin|striker|focus-sash
-hawlucha|-2|swords-dance,acrobatics,close-combat,roost|unburden|grassy-seed
+tsareena|-2|triple-axel,trop-kick,high-jump-kick,u-turn|striker|focus-sash
+meowscarada|-2|u-turn,knock-off,flower-trick,triple-axel|protean|life-orb
+hawlucha|-2|swords-dance,acrobatics,close-combat,stone-edge|unburden|grassy-seed
 bellossom|-2|sleep-powder,quiver-dance,giga-drain,fiery-dance|chlorophyll|leftovers
-rillaboom|-2|swords-dance,grassy-glide,acrobatics,high-horsepower|grassy-surge|grassy-seed
-serperior|-2|leaf-storm,giga-drain,dragon-pulse,leech-seed|contrary|focus-sash
+lilligant-hisui|-2|victory-dance,leaf-blade,close-combat,ice-spinner|hustle|wide-lens
 venusaur|-2|giga-drain,sludge-bomb,earth-power,synthesis|thick-fat|venusaurite
 
 # Elite four

--- a/leagues/radred.txt
+++ b/leagues/radred.txt
@@ -7,61 +7,53 @@
 
 # Evil team
 --ev1|Admin Archer||/leaders/gs-archer
-impidimp|18|thunder-wave,bite,draining-kiss,fake-out|prankster/frisk|oran-berry
-houndour|19|hidden-power,incinerate,thunder-fang,snarl|early-bird/flash-fire|wise-glasses
-mightyena|21|howl,ice-fang,poison-fang,bite|strong-jaw|berry-juice
+glimmet|18|ancient-power,venoshock,mud-shot,protect|toxic-debris|shuca-berry
+houndour|19|hidden-power-grass,incinerate,protect,snarl|unnerve|wise-glasses
+mightyena|21|howl,ice-fang,fire-fang,bite|strong-jaw|berry-juice
 
 --ev2|Giovanni||/leaders/frlg-giovanni#Game corner
 nidoking|45|sludge-bomb,ice-beam,thunderbolt,earth-power|sheer-force|life-orb
 honchkrow|45|drill-peck,sucker-punch,heat-wave,night-slash|super-luck|scope-lens
-infernape|45|thunder-punch,close-combat,swords-dance,pyro-ball|blaze|focus-sash
-rotom-frost>rotom-frost|45|frost-breath,volt-switch,freeze-dry,will-o-wisp|levitate|sitrus-berry
-kangaskhan|46|crunch,body-slam,power-up-punch,fake-out|inner-focus|kangaskhanite
-
---evg3|Giovanni||/leaders/frlg-giovanni#Leader Giovanni?
-rhyhorn|45|scary-face,rock-blast,earthquake,take-down|lightning-rod|
-dugtrio|42|mud-slap,sand-tomb,earthquake,slash|sand-veil|
-nidoqueen|44|poison-sting,double-kick,earthquake,body-slam|poison-touch|
-nidoking|45|poison-sting,double-kick,earthquake,thrash|poison-touch|
-rhyhorn|50|scary-face,rock-blast,earthquake,take-down|lightning-rod|
+tauros-paldea-female|46|bulk-up,close-combat,raging-bull,stone-edge|intimidate|sitrus-berry
+orthworm|45|shed-tail,iron-head,earthquake,body-press|earth-eater|sitrus-berry
+kangaskhan|46|crunch,body-slam,power-up-punch,fake-out|parental-bond|kangaskhanite
 
 --ev3|Archer & Ariana||/leaders/gs-archer
 ==tag:true
-gothitelle|54|hidden-power,shadow-ball,thunder-wave,psychic|competitive|colbur-berry
-aegislash-blade|55|shadow-sneak,shadow-claw,kings-shield,iron-head|stance-change|leftovers
-houndoom|55|scorching-sands,dark-pulse,sucker-punch,heat-wave|unnerve|houndoominite
+gothitelle|54|hidden-power-fighting,shadow-ball,thunder-wave,psychic|competitive|colbur-berry
+gholdengo|55|shadow-ball,make-it-rain,focus-blast,recover|good-as-gold|sitrus-berry
+houndoom|55|scorching-sands,dark-pulse,sucker-punch,heat-wave|dark-aura|houndoominite
 incineroar|54|darkest-lariat,parting-shot,fire-punch,fake-out|intimidate|sitrus-berry
 primarina|55|psychic,scald,dazzling-gleam,hyper-voice|liquid-voice|throat-spray
-mawile|55|iron-head,sucker-punch,thunder-punch,play-rough|intimidate|mawilite
+mawile|55|iron-head,sucker-punch,thunder-punch,play-rough|huge-power|mawilite
 
 --ev4|Admin Archer||/leaders/gs-archer#Cerulean Cave
 mamoswine|77|endeavor,ice-shard,icicle-crash,earthquake|thick-fat|focus-sash
 durant|78|x-scissor,iron-head,superpower,hone-claws|hustle|life-orb
 mimikyu-disguised|79|shadow-claw,swords-dance,shadow-sneak,play-rough|disguise|lum-berry
-houndoom|79|sucker-punch,flamethrower,sludge-bomb,fiery-wrath|unnerve|houndoominite
+houndoom|79|sucker-punch,flamethrower,sludge-bomb,fiery-wrath|solar-power|houndoominite
 
 --evg2|Giovanni||/leaders/frlg-giovanni#Silph co
-hippowdon|54|stealth-rock,rock-slide,roar,earthquake|sand-stream|smooth-rock
-excadrill|55|rock-slide,iron-head,swords-dance,earthquake|sand-rush|focus-sash
-kangaskhan|56|crunch,body-slam,fake-out,power-up-punch|inner-focus|kangaskhanite
-garchomp|56|rock-slide,scale-shot,swords-dance,earthquake|sand-veil|yache-berry
-polteageist|55|giga-drain,shadow-ball,stored-power,shell-smash|weak-armor|white-herb
+hippowdon|56|stealth-rock,stone-edge,roar,earthquake|sand-stream|smooth-rock
+excadrill|57|rock-slide,iron-head,swords-dance,earthquake|sand-rush|focus-sash
+kangaskhan|57|crunch,body-slam,fake-out,power-up-punch|parental-bond|kangaskhanite
+garchomp|57|rock-slide,scale-shot,swords-dance,earthquake|sand-veil|yache-berry
+torterra|56|shell-smash,wood-hammer,earthquake,head-smash|rock-head|white-herb
 
 --ev5|Admin Ariana||/leaders/gs-ariana#Cerulean CAve
-hatterene|77|dazzling-gleam,psychic,mystical-fire,trick-room|magic-bounce|sitrus-berry
-rhyperior|78|ice-punch,rock-blast,heat-crash,earthquake|solid-rock|weakness-policy
-honchkrow|78|drill-peck,night-slash,superpower,sucker-punch|super-luck|scope-lens
-mawile|79|play-rough,iron-head,swords-dance,sucker-punch|intimidate|mawilite
+hatterene|+0|dazzling-gleam,psychic,mystical-fire,trick-room|magic-bounce|sitrus-berry
+rhyperior|+0|ice-punch,rock-blast,heat-crash,earthquake|solid-rock|weakness-policy
+honchkrow|+0|drill-peck,night-slash,superpower,sucker-punch|super-luck|scope-lens
+mawile|+0|play-rough,iron-head,swords-dance,sucker-punch|huge-power|mawilite
 
 --ev6|Giovanni||/leaders/frlg-giovanni#Cerulean Cave
 ==double:true
-scrafty|80|drain-punch,knock-off,ice-punch,roar|moxie|psychic-seed
+scrafty|80|drain-punch,knock-off,ice-punch,roar|intimidate|psychic-seed
 tapu-lele|80|thunderbolt,psychic,focus-blast,moonblast|psychic-surge|terrain-extender
 excadrill|80|rock-slide,iron-head,swords-dance,high-horsepower|sand-rush|focus-sash
 tyranitar|80|high-horsepower,rock-slide,fire-punch,crunch|sand-stream|assault-vest
 celesteela|80|flamethrower,meteor-beam,air-slash,autotomize|beast-boost|power-herb
-mewtwo|80|aura-sphere,soul-robbery,flamethrower,expanding-force|pressure
-mewtwo-mega-y>mewtwo-mega-y|80|aura-sphere,soul-robbery,flamethrower,expanding-force|pressure
+mewtwo|80|aura-sphere,soul-robbery,flamethrower,expanding-force|insomnia|mewtwonite-y
 
 # Rival fights
 --r1|Gary||/leaders/frlg-blue-1#Palette town
@@ -73,54 +65,53 @@ charmander|5|scratch,growl|blaze||grass
 starly|9|tackle,growl,quick-attack,wing-attack|frisk||
 squirtle|9|tackle,tail-whip,bubble|torrent||fire
 bulbasaur|9|tackle,growl,leech-seed,magical-leaf|overgrow||water
-charmander|9|scratch,growl,ember,brick-break|blaze||grass
+charmander|9|false-swipe,growl,ember,brick-break|blaze||grass
 
 --r3|Gary||/leaders/frlg-blue-2#Cerulean
-kirlia|19|magical-leaf,disarming-voice,confusion|synchronize/trace|
-staravia|19|quick-attack,wing-attack|intimidate|
-rockruff|20|howl,bite,rock-tomb|frisk/vital-spirit|
-wartortle|21|bite,water-pulse|torrent|sitrus-berry|fire
-ivysaur|21|sleep-powder,leech-seed,take-down,bullet-seed|overgrow|sitrus-berry|water
-charmeleon|21|ember,scratch|blaze|sitrus-berry|grass
+kirlia|-3|magical-leaf,draining-kiss,psybeam|trace|sitrus-berry
+staravia|-4|quick-attack,pluck,u-turn,sleep-talk|intimidate|muscle-band
+pawniard|-2|knock-off,sucker-punch,cut,low-sweep|defiant|chople-berry
+wartortle|-3|seismic-toss,counter,water-pulse,icy-wind|torrent|eviolite|fire
+ivysaur|-3|sludge,leech-seed,mega-drain,protect|overgrow|eviolite|water
+charmeleon|-3|flame-burst,thunder-punch,ancient-power,bite|blaze|eviolite|grass
 
 --r4|Gary||/leaders/frlg-blue-2#Silph co
 staraptor|54|brave-bird,quick-attack,close-combat,u-turn|intimidate|sharp-beak
+kingambit|53|swords-dance,iron-head,knock-off,sucker-punch|supreme-overlord|chople-berry
 
-electivire|55|close-combat,mach-punch,ice-punch,volt-switch|iron-fist|expert-belt|fire
-darmanitan-standard|55|u-turn,rock-slide,earthquake,flare-blitz|sheer-force|charcoal|fire
-jumpluff|55|seed-bomb,double-edge,swords-dance,sleep-powder|aerilate|sharp-beak|fire
-blastoise|55|aura-sphere,water-pulse,ice-beam,shell-smash|torrent|blastoisinite|fire
+jumpluff|55|leaf-blade,double-edge,swords-dance,sleep-powder|aerilate|sharp-beak|fire
+blastoise|55|aura-sphere,water-pulse,dark-pulse,shell-smash|mega-launcher|blastoisinite|fire
+darmanitan-standard|55|u-turn,rock-slide,earthquake,flare-blitz|sheer-force|life-orb|fire
 
-electivire|55|mach-punch,close-combat,ice-punch,plasma-fists|iron-fist|expert-belt|water
-darmanitan-standard|55|earthquake,rock-slide,u-turn,flare-blitz|sheer-force|charcoal|water
-azumarill|55|play-rough,aqua-jet,ice-punch,liquidation|huge-power|sitrus-berry|water
-venusaur|55|sludge-bomb,giga-drain,earth-power,sleep-powder|overgrow|venusaurite|water
+azumarill|55|play-rough,aqua-jet,ice-punch,liquidation|huge-power|mystic-water|water
+venusaur|55|sludge-bomb,giga-drain,earth-power,sleep-powder|thick-fat|venusaurite|water
+darmanitan-standard|55|u-turn,rock-slide,earthquake,flare-blitz|sheer-force|life-orb|water
 
-electivire|55|ice-punch,close-combat,mach-punch,plasma-fists|iron-fist|expert-belt|grass
-jumpluff|55|double-edge,swords-dance,seed-bomb,sleep-powder|aerilate|sharp-beak|grass
-azumarill|55|aqua-jet,liquidation,ice-punch,play-rough|huge-power|mystic-water|grass
-charizard|55|air-slash,solar-beam,dragon-pulse,flamethrower|blaze|charizardite-y|grass
+jumpluff|55|leaf-blade,double-edge,swords-dance,sleep-powder|aerilate|sharp-beak|grass
+azumarill|53|play-rough,aqua-jet,ice-punch,liquidation|huge-power|mystic-water|grass
+charizard|55|giga-drain,sludge-bomb,earth-power,flamethrower|drought|charizardite-y|grass
 
 
 --r5|Gary||/leaders/frlg-blue-2#Route 22
 
-staraptor|80|brave-bird,double-edge,close-combat,u-turn|intimidate|choice-band
-electivire|80|mach-punch,close-combat,ice-punch,plasma-fists|iron-fist|expert-belt
+staraptor|+0|brave-bird,quick-attack,close-combat,u-turn|intimidate|sharp-beak
+kingambit|+0|iron-head,swords-dance,knock-off,sucker-punch|supreme-overlord|chople-berry
+sneasler|+0|close-combat,u-turn,dire-claw,fire-punch|unburden|focus-sash
 
-azumarill|81|play-rough,ice-punch,liquidation,aqua-jet|huge-power|mystic-water|water
-barbaracle|81|stone-edge,liquidation,earthquake,shell-smash|tough-claws|white-herb|grass
-darmanitan-standard|81|rock-slide,u-turn,earthquake,flare-blitz|sheer-force|life-orb|fire
-darmanitan-standard|81|u-turn,earthquake,rock-slide,flare-blitz|sheer-force|life-orb|water
-hatterene|81|draining-kiss,mystical-fire,calm-mind,psychic|magic-bounce|leftovers|fire
-hatterene|81|psychic,draining-kiss,mystical-fire,calm-mind|magic-bounce|leftovers|grass
+iron-bundle|+0|hydro-pump,freeze-dry,flip-turn,ice-beam|quark-drive|booster-energy|water
+darmanitan-standard|+0|u-turn,earthquake,rock-slide,flare-blitz|sheer-force|life-orb|water
+venusaur|+0|sleep-powder,sludge-bomb,earth-power,chloroblast|thick-fat|venusaurite|water
 
-kartana|81|sacred-sword,smart-strike,x-scissor,leaf-blade|beast-boost|choice-scarf
+sandy-shocks|+0|volt-switch,earth-power,thunder-bold,hidden-power-ice|protosynthesis|booster-energy|grass
+azumarill|+0|aqua-jet,superpower,play-rough,liquidation|huge-power|mystic-water|grass
+charizard|+0|flare-blitz,earthquake,dragon-claw,dragon-dance|tough-claws|charizardite-x|grass
 
-charizard|81|flare-blitz,earthquake,dragon-claw,dragon-dance|blaze|charizardite-x|grass
-blastoise|81|ice-beam,aura-sphere,water-pulse,shell-smash|torrent|blastoisinite|fire
-venusaur|81|sleep-powder,sludge-bomb,earth-power,giga-drain|overgrow|venusaurite|water
+iron-moth|+0|fiery-dance,sludge-wave,energy-ball,dazzling-gream|quark-drive|booster-energy|fire
+azumarill|+0|aqua-jet,superpower,play-rough,liquidation|huge-power|mystic-water|fire
+blastoise|+0|ice-beam,dark-pulse,hydro-pump,shell-smash|mega-launcher|blastoisinite|fire
 
---m1|May||/leaders/rs-may-oras@Hyo@https://www.deviantart.com/hyo-oppa#Cinnibar Island
+
+--m1|May||/leaders/rs-may-oras@Hyo@https://www.deviantart.com/hyo-oppa#Cinnabar Island
 solrock|71|explosion,photon-geyser,earthquake,stealth-rock|levitate|focus-sash
 breloom|71|focus-punch,substitute,rock-slide,spore|poison-heal|toxic-orb
 manectric|72|overheat,thunderbolt,switcheroo,volt-switch|lightning-rod|choice-specs
@@ -132,99 +123,83 @@ blaziken|73|flare-blitz,close-combat,rock-slide,swords-dance|speed-boost|blazike
 corphish|7|vice-grip,bubble,harden,leer|battle-armor|
 treecko|8|pound,leer,absorb|overgrow|
 
---b2|Brendan||/leaders/rs-brendan#Diglett Cave
-loudred|28|ice-beam,brick-break,shadow-ball,hyper-voice|punk-rock|chople-berry
-lunatone|28|hypnosis,power-gem,calm-mind,psyshock|levitate|colbur-berry
-crawdaunt|29|knock-off,waterfall,x-scissor,aqua-jet|adaptability|focus-sash
-grovyle|29|leaf-blade,aerial-ace,rock-tomb,power-up-punch|overgrow|sitrus-berry
+--b2|Brendan||/leaders/rs-brendan#S.S. Anne
+loudred|-2|ice-beam,brick-break,shadow-ball,hyper-voice|punk-rock|chople-berry
+lunatone|-2|hypnosis,power-gem,calm-mind,psyshock|levitate|colbur-berry
+crawdaunt|-2|knock-off,waterfall,x-scissor,aqua-jet|adaptability|focus-sash
+grovyle|-2|leaf-blade,aerial-ace,rock-tomb,power-up-punch|overgrow|sitrus-berry
 
---b3|Brendan||/leaders/rs-brendan#Safari Zone
-metagross|61|explosion,meteor-mash,earthquake,stealth-rock|clear-body|air-balloon
-medicham|62|thunder-punch,close-combat,ice-punch,psycho-cut|huge-power|choice-scarf
-crawdaunt|62|crunch,liquidation,superpower,aqua-jet|adaptability|choice-band
-exploud|63|flamethrower,surf,shadow-ball,boomburst|punk-rock|silk-scarf
-gardevoir|63|psychic,moonblast,thunderbolt,focus-blast|trace|pixie-plate
-sceptile|63|dual-chop,bullet-seed,earthquake,swords-dance|overgrow|sceptilite
+--b3|Brendan||/leaders/rs-brendan#Fuchsia City
+metagross|-2|explosion,meteor-mash,earthquake,stealth-rock|clear-body|air-balloon
+crawdaunt|-2|crunch,liquidation,superpower,aqua-jet|adaptability|choice-band
+medicham|-2|thunder-punch,close-combat,ice-punch,psycho-cut|huge-power|choice-scarf
+gardevoir|-2|psychic,moonblast,thunderbolt,focus-blast|trace|pixie-plate
+exploud|-2|flamethrower,surf,shadow-ball,boomburst|punk-rock|silk-scarf
+sceptile|-2|dual-chop,bullet-seed,earthquake,swords-dance|technician|sceptilite
 
---b4|Brendan||/leaders/rs-brendan#Indigo plateau
-deoxys-attack|81|superpower,ice-beam,extreme-speed,psychic|pressure|focus-sash
-jirachi|81|thunder-punch,u-turn,zen-headbutt,iron-head|serene-grace|choice-scarf
-landorus-therian>landorus-therian|82|sludge-wave,rock-slide,aura-sphere,earth-power|sand-force|life-orb
-zapdos|81|u-turn,close-combat,blaze-kick,brave-bird|defiant|choice-band
-huntail|81|crunch,liquidation,ice-fang,shell-smash|intimidate|white-herb
-sceptile|82|bullet-seed,scale-shot,earthquake,swords-dance|overgrow|sceptilite
+--b4|Brendan||/leaders/rs-brendan#Route 23
+deoxys-attack|+0|superpower,ice-beam,extreme-speed,psychic|pressure|focus-sash
+jirachi|+0|thunder-punch,u-turn,zen-headbutt,iron-head|serene-grace|choice-scarf
+landorus-therian>landorus-therian|+0|sludge-wave,rock-slide,aura-sphere,earth-power|sand-force|life-orb
+huntail|+0|crunch,liquidation,ice-fang,shell-smash|intimidate|white-herb
+zapdos-galar|+0|u-turn,close-combat,blaze-kick,brave-bird|defiant|choice-band
+sceptile|+0|bullet-seed,scale-shot,earthquake,swords-dance|technician|sceptilite
 
 # Johto leaders
 --mb1|Falkner|flying|/leaders/gs-falkner#Pre brock
-rufflet|13|aerial-ace,slash,rock-smash,roost|hustle|berry-juice
-emolga|13|shock-wave,air-cutter,sleep-talk,roost|lightning-rod|berry-juice
-corvisquire|14|pluck,roost,rock-smash,hone-claws|unnerve|berry-juice
+rufflet|12|aerial-ace,rock-smash,rock-tomb,roost|hustle|berry-juice
+wattrel|14|flash,air-slash,sleep-talk,roost|volt-absorb|berry-juice
+flittle|14|disarming-voice,roost,psybeam,calm-mind|speed-boost|eviolite
 
 --mb2|Bugsy|bug|/leaders/gs-bugsy#Pre Surge
-ariados|-2|shadow-sneak,fell-stinger,bug-bite,poison-fang|swarm|poison-barb
-scyther|-2|bug-bite,aerial-ace,brick-break,swords-dance|technician|charti-berry
-ledian|-2|drain-punch,ice-punch,mach-punch,u-turn|iron-fist|focus-sash
-scizor|-2|bullet-punch,u-turn,aerial-ace,roost|technician|sitrus-berry
+lokix|-2|first-impression,knock-off,u-turn,leech-life|tinted-lens|silver-powder
+ledian|-2|drain-punch,ice-punch,mach-punch,thunder-punch|iron-fist|focus-sash
+scyther|-2|bug-bite,aerial-ace,rock-smash,swords-dance|technician|charti-berry
+scizor|-2|bullet-punch,u-turn,aerial-ace,rock-smash|technician|sitrus-berry
 
 --mb2b|Bugsy|bug|/leaders/gs-bugsy#Post Surge
-kleavor|-2|stealth-rock,rock-blast,u-turn,bulldoze|technician|focus-sash
-araquanid|-2|x-scissor,liquidation,protect,toxic|water-bubble|leftovers
+kleavor|-2|stone-axe,x-scissor,u-turn,night-slash|sharpness|focus-sash
 scizor|-2|bullet-punch,dual-wingbeat,u-turn,rock-smash|technician|scizorite
 scyther|-2|swords-dance,dual-wingbeat,bug-bite,rock-smash|technician|eviolite
-heracross|-2|megahorn,close-combat,stone-edge,bullet-seed|moxie|occa-berry
+lokix|-2|first-impression,knock-off,u-turn,sucker-punch|tinted-lens|bug-gem
+araquanid|-2|x-scissor,liquidation,protect,toxic|water-bubble|leftovers
 vikavolt|-2|thunder,bug-buzz,volt-switch,energy-ball|levitate|magnet
 
 --mb3|Whitney|normal|/leaders/gs-whitney#Route 11
-wigglytuff|-2|drain-punch,fire-punch,lovely-kiss,play-rough|sheer-force|sitrus-berry
-miltank|-2|body-slam,body-press,stomping-tantrum,milk-drink|thick-fat|leftovers
-vigoroth|-2|bulk-up,slack-off,body-slam,knock-off|vital-spirit|eviolite
-indeedee-female|-2|psyshock,hyper-voice,mystical-fire,draining-kiss|psychic-surge|twisted-spoon
-drampa|-2|dragon-breath,roost,flamethrower,thunderbolt|berserk/sap-sipper|leftovers
+tinkaton|+0|play-rough,iron-head,knock-off,encore|mold-breaker|sitrus-berry
+farigiraf|+0|shadow-ball,hyper-voice,psychic,dazzling-gleam|parental-bond|twisted-spoon
+miltank|+0|body-slam,slack-off,zen-headbutt,high-horsepower|thick-fat|chople-berry
+drampa|+0|dragon-breath,roost,flamethrower,hyper-voice|sap-sipper|normal-gem
+dudunsparce|+0|body-slam,roost,bite,coil|serene-grace|leftovers
 
 --mb4|Morty|ghost|/leaders/gs-morty
 mimikyu-disguised|-2|play-rough,shadow-claw,shadow-sneak,swords-dance|disguise|lum-berry
-zoroark-hisui>zoroark-hisui|-2|hyper-voice,shadow-ball,flamethrower,nasty-plot|illusion|colbur-berry
 dusknoir|-2|shadow-punch,shadow-sneak,dynamic-punch,will-o-wisp|hustle|reaper-cloth
+zoroark-hisui>zoroark-hisui|-2|hyper-voice,shadow-ball,flamethrower,nasty-plot|illusion|colbur-berry
+skeledirge|-2|torch-song,will-o-wisp,hex,slack-off|unaware|leftovers
 gengar|-2|shadow-ball,sludge-wave,nasty-plot,focus-blast|shadow-tag|gengarite
-weavile|-2|triple-axel,knock-off,ice-shard,swords-dance|infiltrator|focus-sash
-typhlosion-hisui>typhlosion-hisui|-2|flamethrower,infernal-parade,focus-blast,hidden-power-grass|flash-fire|charcoal
+ceruledge|44|bitter-blade,shadow-sneak,close-combat,swords-dance|sharpness|focus-sash
 
 --mb5|Chuck|fighting|/leaders/gs-chuck# Saffron City Dojo
 hitmontop|-2|triple-kick,triple-axel,brutal-swing,fake-out|technician|focus-sash
-poliwrath|-2|surging-strikes,drain-punch,ice-punch,earthquake|water-absorb|mystic-water
-breloom|-2|spore,substitute,rock-slide,focus-punch|poison-heal|toxic-orb
-lucario|-2|bulk-up,extreme-speed,close-combat,meteor-mash|inner-focus|shuca-berry
-gallade|-2|drain-punch,psycho-cut,bulk-up,night-slash|inner-focus|galladite
 sneasler|-2|close-combat,poison-jab,knock-off,stone-edge|poison-touch|focus-sash
+breloom|-2|spore,substitute,rock-slide,focus-punch|poison-heal|toxic-orb
+quaquaval|-2|aqua-step,close-combat,bulk-up,ice-spinner|moxie|mystic-water
+lucario|-2|bulk-up,extreme-speed,close-combat,meteor-mash|inner-focus|shuca-berry
+gallade|-2|drain-punch,psycho-cut,bulk-up,night-slash|blade-master|galladite
 
---mb6a|Pryce (Team A)|ice|/leaders/gs-pryce
-vanilluxe|-2|blizzard,freeze-dry,ice-shard,flash-cannon|snow-warning|light-clay
-weavile|-2|triple-axel,knock-off,low-kick,ice-shard|pressure|choice-band
-crabominable|-2|mach-punch,ice-shard,drain-punch,ice-hammer|iron-fist|assault-vest
-dewgong|-2|rest,sleep-talk,surf,toxic|ice-scales|leftovers
-arctovish|-2|fishious-rend,icicle-crash,psychic-fangs,icicle-spear|slush-rush|choice-band
-glalie|-2|double-edge,earthquake,ice-shard,crunch|refrigerate|glalitite
-
---mb6b|Pryce (Team B)|ice|/leaders/gs-pryce
-jynx|-2|lovely-kiss,freeze-dry,psystrike,substitute|dry-skin/forewarn|focus-sash
-mr-rime|-2|freeze-dry,psychic,ice-beam,focus-blast|screen-cleaner|choice-specs
-mamoswine|-2|earthquake,ice-shard,icicle-crash,knock-off|thick-fat|life-orb
-walrein|-2|rest,sleep-talk,surf,toxic|fur-coat|leftovers
-arctovish|-2|fishious-rend,psychic-fangs,icicle-crash,icicle-spear|water-absorb|choice-scarf
-glalie|-2|double-edge,earthquake,ice-shard,crunch|refrigerate|glalitite
-
---mb6c|Prye (Team C)|ice|/leaders/gs-pryce
-ninetales-alola>ninetales-alola|-2|aurora-veil,freeze-dry,blizzard,moonblast|snow-warning|icy-rock
-sandslash-alola>sandslash-alola|-2|earthquake,icicle-crash,iron-head,ice-shard|ice-scales|assault-vest
-beartic|-2|play-rough,triple-axel,superpower,swords-dance|slush-rush|focus-sash
-arctozolt|-2|bolt-beak,icicle-crash,stomping-tantrum,rock-slide|slush-rush|choice-band
-frosmoth|-2|quiver-dance,ice-beam,bug-buzz,giga-drain|ice-scales|leftovers
-glalie|-2|double-edge,earthquake,crunch,ice-shard|refrigerate|glalitite
+--mb6a|Pryce|ice|/leaders/gs-pryce
+jynx|-2|lovely-kiss,freeze-dry,psystrike,focus-blast|dry-skin|focus-sash
+cloyster|-2|shell-smash,icicle-spear,waterfall,rock-blast|skill-link|white-herb
+walrein|-2|rest,sleep-talk,ice-beam,toxic|fur-coat|leftovers
+baxcalibur|-2|dragon-dance,icicle-crash,glaive-rush,earthquake|thermal-exchange|dragon-fang
+arctozolt|-2|bolt-beak,icicle-crash,freeze-dry,low-kick|slush-rush|life-orb
+glalie|-2|double-edge,earthquake,quick-attack,fake-out|refrigerate|glalitite
 
 --mb7a|Jasmine (Team A)|steel|/leaders/gs-jasmine
 steelix|-2|stealth-rock,iron-head,earthquake,roar|sturdy|chople-berry
 melmetal|-2|double-iron-bash,earthquake,superpower,thunder-punch|clear-body|choice-band
-aegislash-blade|-2|shadow-ball,shadow-sneak,close-combat,kings-shield|stance-change|leftovers
+aegislash|-2|shadow-ball,shadow-sneak,close-combat,kings-shield|stance-change|leftovers
 durant|-2|iron-head,superpower,x-scissor,hone-claws|hustle|life-orb
 duraludon|-2|draco-meteor,flash-cannon,thunderbolt,dragon-pulse|light-metal|assault-vest
 aggron|-2|heavy-slam,earthquake,fire-punch,dragon-claw|filter|aggronite

--- a/leagues/radred.txt
+++ b/leagues/radred.txt
@@ -248,36 +248,36 @@ aggron|-2|dragon-claw,heavy-slam,earthquake,fire-punch|filter|aggronite
 # -- Done with swapping ability and item
 
 # Gym leaders
---1|Brock|rock|/leaders/frlg-brock
+--1|Brock|rock|/leaders/frlg-brock 
 geodude-alola>geodude-alola|13|spark,rock-tomb,self-destruct,bulldoze|sturdy|custap-berry
-vulpix|14|incinerate,ominous-wind,hidden-power-grass,sleep-talk|flash-fire|oran-berry
-archen|12|pluck,rock-tomb,bulldoze,roost|defeatist|oran-berry
+varoom|13|toxic,protect,gyro-ball,bulldoze|solid-rock|air-balloon
+archen|12|pluck,rock-tomb,bulldoze,facade|defeatist|berry-juice
 onix|14|rock-tomb,bulldoze,sleep-talk,|sturdy|berry-juice
 
 --2|Misty|water|/leaders/frlg-misty
 frogadier|25|ice-punch,rock-tomb,flip-turn,grass-knot|protean|eviolite
 floatzel|25|water-pulse,flip-turn,icy-wind,hidden-power-grass|technician|mystic-water
-starmie|27|scald,recover,psyshock,aurora-beam|analytic|sitrus-berry
-lanturn|25|parabolic-charge,scald,icy-wind,hidden-power-grass|volt-absorb|iapapa-berry
+starmie|27|water-pulse,recover,psyshock,aurora-beam|analytic|sitrus-berry
+clodsire|26|rock-tomb,recover,poison-jab,bulldoze|water-absorb|iapapa-berry
 
 --3|Lt. Surge|electric|/leaders/frlg-surge
-pincurchin|32|volt-switch,scald,discharge,hidden-power-grass|electric-surge|electric-seed
-raichu-alola>raichu-alola|33|psyshock,volt-switch,nasty-plot,grass-knot|surge-surfer|twisted-spoon
-vikavolt|33|volt-switch,bug-buzz,energy-ball,roost|levitate|occa-berry
-boltund|33|thunder-fang,fire-fang,ice-fang,psychic-fangs|strong-jaw|expert-belt
+pincurchin|32|volt-switch,scald,discharge,hidden-power-ice|electric-surge|terrain-extender
+raichu-alola>raichu-alola|33|psyshock,discharge,nasty-plot,grass-knot|surge-surfer|focus-sash
+bellibolt|33|parabolic-charge,muddy-water,thunder-wave,hidden-power-grass|electromorphosis|shuca-berry
+pawmot|33|drain-punch,thunder-punch,ice-punch,mach-punch|iron-fist|punching-glove
 manectric|34|charge-beam,flame-burst,volt-switch,hidden-power-grass|intimidate|manectite
 
 --4|Erika|grass|/leaders/frlg-erika
 rillaboom|43|u-turn,high-horsepower,drain-punch,grassy-glide|grassy-surge|terrain-extender
 meganium|44|giga-drain,dazzling-gleam,ancient-power,hidden-power-fire|triage|grassy-seed
-serperior|43|leaf-storm,giga-drain,dragon-pulse,hidden-power-fire|contrary|focus-sash
-electrode-hisui>electrode-hisui|44|thunderbolt,chloroblast,hidden-power-ice,explosion|reckless|life-orb
+meowscarada|43|flower-trick,knock-off,u-turn,triple-axel|protean|focus-sash
+electrode-hisui>electrode-hisui|44|thunderbolt,chloroblast,hidden-power-fire,explosion|reckless|life-orb
 venusaur|44|giga-drain,sludge-bomb,sleep-powder,earth-power|thick-fat|venusaurite
 
 --5|Sabrina|psychic|/leaders/frlg-sabrina
 hatterene|57|trick-room,expanding-force,draining-kiss,mystical-fire|magic-bounce|psychic-seed
-indeedee-female|57|expanding-force,hyper-voice,mystical-fire,shadow-ball|psychic-surge|terrain-extender
-crawdaunt|58|knock-off,liquidation,aqua-jet,brick-break|adaptability|focus-sash
+indeedee-female|59|expanding-force,hyper-voice,mystical-fire,shadow-ball|psychic-surge|terrain-extender
+brute-bonnet|58|knock-off,leaf-blade,close-combat,spore|protosynthetis|booster-energy
 ursaluna|59|protect,high-horsepower,facade,crunch|guts|flame-orb
 porygon2|58|trick-room,teleport,ice-beam,thunderbolt|trace|eviolite
 gardevoir|59|hyper-voice,expanding-force,shadow-ball,trick-room|pixilate|gardevoirite
@@ -286,22 +286,22 @@ gardevoir|59|hyper-voice,expanding-force,shadow-ball,trick-room|pixilate|gardevo
 swellow|67|boomburst,u-turn|aerilate|choice-specs
 accelgor|68|bug-buzz,u-turn,focus-blast,sludge-bomb|sheer-force|life-orb
 drapion|68|wicked-blow,cross-poison,,|sniper|choice-scarf
-greninja|68|surf,water-shuriken,dark-pulse,ice-beam|battle-bond|life-orb
-dragapult|68|shadow-ball,flamethrower,dragon-pulse,u-turn|infiltrator|life-orb
-toxtricity-low-key|68|volt-switch,boomburst,sludge-bomb,overdrive|punk-rock|toxtricitite
+greninja|68|hydro-pump,water-shuriken,dark-pulse,ice-beam|battle-bond|life-orb
+iron-valiant|68|close-combat,spirit-break,knock-off,liquidation|quark-drive|booster-energy
+toxtricity-low-key|68|hidden-power-grass,boomburst,sludge-bomb,overdrive|punk-rock|toxtricitite
 
 --7|Blaine|fire|/leaders/frlg-blaine
-torkoal|75|stealth-rock,explosion,lava-plume,earth-power|drought|heat-rock
-sunflora|76|seed-flare,flamethrower,earth-power,sunny-day|chlorophyll|life-orb
-cinderace|75|pyro-ball,sucker-punch,high-jump-kick,zen-headbutt|protean|life-orb
-typhlosion|76|eruption,flamethrower,hidden-power-ice,focus-blast|blazing-soul|heavy-duty-boots
-exeggutor|76|growth,giga-drain,psyshock,weather-ball|harvest|focus-sash
+armarouge|75|armor-cannon,psyshock,aura-sphere,energy-ball|mega-launcher|focus-sash
+slither-wing|76|first-impression,u-turn,close-combat,flare-blitz|protosynthesis|life-orb
+scovillain|76|giga-drain,fire-blast,growth,hidden-power-rock|chlorophyll|life-orb
+typhlosion|76|eruption,flamethrower,hidden-power-grass,focus-blast|blazing-soul|heavy-duty-boots
+exeggutor|76|growth,giga-drain,psyshock,weather-ball|chlorophyll|lum-berry
 charizard|76|flamethrower,air-slash,solar-beam,dragon-pulse|drought|charizardite-y
 
 --8|Clair|dragon|/leaders/gs-clair
-aerodactyl|80|stealth-rock,stone-edge,earthquake,taunt|pressure|focus-sash
+aerodactyl|80|stealth-rock,stone-edge,earthquake,taunt|unnerve|focus-sash
 magearna|81|shift-gear,fleur-cannon,flash-cannon,aura-sphere|soul-heart|leftovers
-dracovish|80|fishious-rend,psychic-fangs,outrage,crunch|strong-jaw|choice-scarf
+roaring-moon|81|dragon-dance,crunch,earthquake,iron-head|protosynthesis|booster-energy
 dragonite|80|extreme-speed,dragon-dance,fire-punch,dual-wingbeat|multiscale|weakness-policy
 naganadel|81|nasty-plot,sludge-wave,draco-meteor,flamethrower|beast-boost|life-orb
 duraludon|81|draco-meteor,steel-beam,thunderbolt,dark-pulse|bad-company|duraludite
@@ -342,76 +342,78 @@ venusaur|-2|giga-drain,sludge-bomb,earth-power,synthesis|thick-fat|venusaurite
 
 --e1a|Lorelei (Rain Team)|ice|/leaders/frlg-lorelei
 ==double:true
-poliwrath|84|flip-turn,close-combat,ice-punch,surging-strikes|water-absorb|focus-sash
-politoed|84|scald,rain-dance,haze,flip-turn|drizzle|damp-rock
-swampert|85|power-up-punch,earthquake,ice-punch,liquidation|swift-swim|swampertite
-kingdra|85|muddy-water,dragon-pulse,ice-beam,hurricane|swift-swim|life-orb
-kyogre-primal>kyogre-primal|85|water-sport,origin-pulse,thunder,ice-beam|primordial-sea|blue-orb
-dracovish|85|fishious-rend,outrage,psychic-fangs,crunch|strong-jaw|choice-scarf
+poliwrath|85|flip-turn,close-combat,ice-punch,surging-strikes|wift-swim|focus-sash
+politoed|85|scald,rain-dance,haze,flip-turn|drizzle|damp-rock
+swampert|85|power-up-punch,earthquake,ice-punch,waterfall|swift-swim|swampertite
+walking-wake|85|protect,hurricane,hydro-pump,dragon-pulse|protosynthesis|life-orb
+kyogre-primal>kyogre-primal|85|water-spout,origin-pulse,thunder,ice-beam|primordial-sea|blue-orb
+iron-bundle|85|hydro-pump,freeze-dry,ice-beam,flip-turn|quark-drive|focus-sash
 
 --e1b|Lorelei (Hail Team)|ice|/leaders/frlg-lorelei
 ==double:true
-ninetales-alola>ninetales-alola|84|blizzard,aurora-veil,freeze-dry,hail|snow-warning|light-clay
-glaceon|84|blizzard,earth-power,freeze-dry,hidden-power-fire|slush-rush|choice-specs
-calyrex-ice>calyrex-ice|85|glacial-lance,high-horsepower,zen-headbutt,seed-bomb|as-one|choice-band
-rotom-wash>rotom-wash|85|volt-switch,hydro-pump,hail,thunder-wave|levitate|wiki-berry
-azumarill|85|aqua-jet,liquidation,play-rough,knock-off|huge-power|assault-vest
+ninetales-alola>ninetales-alola|85|blizzard,aurora-veil,freeze-dry,hail|snow-warning|light-clay
+glaceon|85|blizzard,earth-power,freeze-dry,knock-off|slush-rush|choice-specs
+calyrex-ice>calyrex-ice|85|glacial-lance,high-horsepower,zen-headbutt,seed-bomb|as-one|assault-vest
+rotom-wash>rotom-wash|85|volt-switch,scald,hail,thunder-wave|levitate|sitrus-berry
+baxcalibur|85|glaive-rush,protect,icicle-crash,ice-shard|thermal-exchange|dragon-fang
 abomasnow|85|blizzard,focus-blast,hidden-power-fire,energy-ball|slush-rush|abomasite
 
 --e2a|Bruno (Team A)|fighting|/leaders/frlg-bruno
-infernape|84|taunt,pyro-ball,stealth-rock,close-combat|blaze|focus-sash
-conkeldurr|85|drain-punch,mach-punch,knock-off,ice-punch|iron-fist|assault-vest
-urshifu-single-strike|85|u-turn,close-combat,wicked-blow,poison-jab|unseen-fist|choice-scarf
-zacian-crowned|85|swords-dance,behemoth-blade,close-combat,crunch|intrepid-sword|rusted-sword
-kommo-o|85|clanging-scales,clangorous-soul,aura-sphere,flash-cannon|overcoat|throat-spray
-lucario|85|bullet-punch,meteor-mash,close-combat,swords-dance|adaptability|lucarionite
-
---e2b|Bruno (Team B)|fighting|/leaders/frlg-bruno
-urshifu-rapid-strike|84|surging-strikes,close-combat,aqua-jet,u-turn|unseen-fist|focus-sash
-scizor|85|bullet-punch,superpower,u-turn,swords-dance|technician|life-orb
-terrakion|85|stone-edge,close-combat,earthquake,x-scissor|justified|choice-scarf
-zacian-crowned|85|swords-dance,behemoth-bash,close-combat,crunch|intrepid-sword|rusted-sword
-conkeldurr|85|drain-punch,ice-punch,mach-punch,knock-off|iron-fist|assault-vest
+great-tusk|85|headlong-rush,close-combat,stealth-rock,knock-off|protosynthesis|focus-sash
+urshifu-rapid-strike|85|surging-strikes,close-combat,swords-dance,thunder-punch|unseen-fist|mystic-water
+iron-valiant|85|psyshock,shadow-ball,moonblast,calm-mind|quark-drive|booster-energy
+zacian-crowned|85|swords-dance,behemoth-blade,close-combat,wild-charge|intrepid-sword|rusted-sword
+iron-hands|85|drain-punch,fake-out,plasma-fists,ice-punch|quark-drive|assault-vest
 lucario|85|nasty-plot,aura-sphere,vacuum-wave,flash-cannon|adaptability|lucarionite
 
+--e2b|Bruno (Team B)|fighting|/leaders/frlg-bruno
+infernape|85|taunt,pyro-ball,stealth-rock,close-combat|blaze|focus-sash
+kommo-o|85|clanging-scales,clangorous-soul,aura-sphere,flash-cannon|overcoat|throat-spray
+urshifu-single-strike|85|swords-dance,close-combat,wicked-blow,sucker-punch|unseen-fist|black-glasses
+zacian-crowned|85|swords-dance,behemoth-blade,close-combat,crunch|intrepid-sword|rusted-sword
+iron-valiant|85|moonblast,thunderbolt,aura-sphere,shadow-ball|quark-drive|booster-energy
+lucario|85|bullet-punch,meteor-mash,close-combat,swords-dance|adaptability|lucarionite
+
 --e3a|Agatha (Team A)|ghost|/leaders/frlg-agatha
-zoroark|84|taunt,dark-pulse,flamethrower,sludge-bomb|illusion|focus-sash
-spectrier|85|shadow-ball,hidden-power-fighting,dark-pulse,sleep-talk|grim-neigh|choice-scarf
-marshadow|85|spectral-thief,close-combat,shadow-sneak,bulk-up|technician|focus-sash
-silvally|85|multi-attack,flamethrower,thunder-wave,parting-shot|battle-armor|leftovers
-aegislash-blade|85|shadow-ball,toxic,flash-cannon,kings-shield|stance-change|leftovers
-gengar|85|shadow-ball,sludge-wave,nasty-plot,thunderbolt|shadow-tag|gengarite
+zoroark-hisui|85|taunt,hyper-voice,flamethrower,shadow-ball|illusion|focus-sash
+gholdengo|85|make-it-rain,thunder-wave,shadow-ball,focus-blast|good-as-gold|air-balloon
+marshadow|85|spectral-thief,drain-punch,shadow-sneak,bulk-up|technician|focus-sash
+roaring-moon|85|dragon-dance,crunch,earthquake,iron-head|protosynthesis|booster-energy
+chi-yu|85|dark-pulse,flamethrower,psychic,hidden-power-grass|beads-of-ruin|charcoal
+gengar|85|shadow-ball,sludge-wave,nasty-plot,focus-blast|shadow-tag|gengarite
 
 --e3b|Agatha (Team B)|ghost|/leaders/frlg-agatha
-grimmsnarl|84|spirit-break,taunt,light-screen,reflect|prankster|light-clay
-spectrier|85|shadow-ball,dark-pulse,hidden-power-fighting,sleep-talk|grim-neigh|choice-scarf
-marshadow|85|drain-punch,bulk-up,spectral-thief,shadow-sneak|technician|focus-sash
-dragapult|85|dragon-dance,dragon-darts,steel-wing,phantom-force|cursed-body|life-orb
-hydreigon|85|dark-pulse,thunder-wave,dragon-pulse,flamethrower|levitate|leftovers
-gengar|85|sludge-wave,shadow-ball,nasty-plot,thunderbolt|shadow-tag|gengarite
+zoroark|85|taunt,dark-pulse,flamethrower,sludge-bomb|illusion|focus-sash
+flutter-mane|85|mystical-fire,moonblast,shadow-ball,psyshock|protosynthesis|booster-energy
+marshadow|85|spectral-thief,close-combat,shadow-sneak,bulk-up|technician|focus-sash
+chien-pao|85|sacred-sword,crunch,icicle-crash,ice-shard|swords-of-ruin|black-glasses
+gholdengo|85|make-it-rain,nasty-plot,shadow-ball,focus-blast|good-as-gold|air-balloon
+gengar|85|shadow-ball,sludge-wave,nasty-plot,focus-blast|shadow-tag|gengarite
 
 --e4a|Lance (Team A)|dragon|/leaders/frlg-lance
-garchomp|85|stealth-rock,earthquake,stone-edge,roar|rough-skin|focus-sash
-dragonite|85|dragon-dance,extreme-speed,earthquake,dual-wingbeat|multiscale|lum-berry
-dracozolt|85|bolt-beak,dragon-claw,earthquake,flamethrower|hustle|choice-scarf
+aerodactyl|85|stealth-rock,earthquake,taunt,stone-edge|pressure|focus-sash
 melmetal|85|double-iron-bash,earthquake,thunder-punch,ice-punch|iron-fist|assault-vest
-dialga-origin>dialga-origin|85|roar-of-time,rest,sleep-talk,flamethrower|primal-armor|adamant-orb
+dialga-primal>dialga-primal|85|roar-of-time,rest,sleep-talk,flash-cannon|primal-armor|adamant-orb
+iron-jugulis|85|dark-hole,flamethrower,aeroblast,earth-power|quark-drive|booster-energy
+dragonite|85|dragon-dance,extreme-speed,earthquake,dual-wingbeat|multiscale|weakness-policy
 salamence|85|dragon-dance,double-edge,fire-fang,earthquake|aerilate|salamencite
 
 --e4b|Lance (Team B)|dragon|/leaders/frlg-lance
-aerodactyl|85|stealth-rock,earthquake,taunt,stone-edge|rock-head|focus-sash
-dracovish|85|fishious-rend,outrage,psychic-fangs,crunch|strong-jaw|choice-scarf
-dragonite|85|extreme-speed,outrage,dual-wingbeat,earthquake|multiscale|choice-band
-melmetal|85|double-iron-bash,earthquake,thunder-punch,ice-punch|clear-body|assault-vest
-dialga-origin>dialga-origin|85|roar-of-time,flamethrower,rest,sleep-talk|primal-armor|adamant-orb
+garchomp|85|stealth-rock,earthquake,stone-edge,roar|rough-skin|focus-sash
+dragonite|85|extreme-speed,dragon-dance,dual-wingbeat,earthquake|multiscale|lum-berry
+iron-jugulis|85|dark-hole,flamethrower,aeroblast,earth-power|quark-drive|booster-energy
+melmetal|85|double-iron-bash,earthquake,thunder-punch,ice-punch|iron-fist|assault-vest
+dialga-primal>dialga-primal|85|roar-of-time,flash-cannon,rest,sleep-talk|primal-armor|adamant-orb
 salamence|85|dragon-dance,double-edge,earthquake,fire-fang|aerilate|salamencite
 
 --ec|Champion Gary||/leaders/frlg-blue-3
 pheromosa|85|triple-axel,close-combat,poison-jab,u-turn|beast-boost|focus-sash
-metagross|85|fire-punch,zen-headbutt,meteor-mash,bullet-punch|clear-body|metagrossite
-groudon-primal>groudon-primal|85|thunder-wave,precipice-blades,stone-edge,fire-punch|drought|red-orb
+metagross|85|fire-punch,zen-headbutt,meteor-mash,bullet-punch|tough-claws|metagrossite
+miraidon|85|calm-mind,parabolic-charge,dragon-pulse,hidden-power-fire|hadron-engine|leftovers|fire
+koraidon|85|swords-dance,collision-course,dragon-claw,flare-blitz|hadron-engine|lum-berry|grass
+miraidon|85|calm-mind,parabolic-charge,dragon-pulse,hidden-power-fire|hadron-engine|leftovers|water
 yveltal|85|heat-wave,dark-hole,sucker-punch,oblivion-wing|dark-aura|assault-vest
-eternatus|85|flamethrower,sludge-bomb,dynamax-cannon,meteor-beam|pressure|power-herb
+eternatus|85|flamethrower,sludge-wave,dynamax-cannon,meteor-beam|pressure|power-herb
 ditto|85|transform|imposter|choice-scarf
 
 ###############################################################

--- a/patches/radred.txt
+++ b/patches/radred.txt
@@ -18,6 +18,17 @@ rock-smash||60
 kings-shield|||Protects from damaging attacks.
 roar-of-time||80|Forces the target to switch to a random ally.
 ice-hammer|||No effect
+bleakwind-storm|||20% chance to inflict frostbite
+springtide-storm|||Cannot miss in rain
+chloroblast||150|50% recoil damage
+dire-claw||80
+esper-wing||80|The user slashes the target with aura- enriched wings that raise Speed. It has a high crit ratio.
+hail|||A 5-turn snowstorm that boosts the Def of Ice-types by 50%.
+glacial-lance||120
+grassy-glide||60
+psyshield-bash|||The user slams into the foe with psychic energy. It raises the user's Defense too.
+spin-out||110
+wicked-blow||75
 
 # New moves
 soul-robbery|psychic|100|The target's stat increases are stolen from it and applied to the user before dealing damage.|special

--- a/patches/radred.txt
+++ b/patches/radred.txt
@@ -107,7 +107,7 @@ sage-power|This Pokemon's Sp. Atk is 1.5x, but it can only select the first move
 100,,90|quagsire
 ,,80,,75|dunsparce
 100|granbull|fairy,fighting
-,105|qwilfish
+80,105|qwilfish
 ,100,,,,105|delibird
 100,,80,55,80|ursaring
 85,,100,,100|corsola
@@ -164,11 +164,11 @@ sage-power|This Pokemon's Sp. Atk is 1.5x, but it can only select the first move
 100,,79,,79|purugly
 ,,,91|skuntank
 ,,,,,101|chatot
-,80|drapion
+,90|drapion
 89,,82,55,82|carnivine
 79,59,,96,69,101|lumineon
 ,95,,,,30|lickilicky
-,113,,105|electivire
+,123,,95|electivire|electric
 ,80,,,,98|magmortar
 ,130,110|leafeon
 80,45,100,,,75|glaceon
@@ -241,8 +241,17 @@ sage-power|This Pokemon's Sp. Atk is 1.5x, but it can only select the first move
 ,110|morpeko
 ,,79,,79|copperajah
 ,,,55,,80|arctovish
-,,,,55,80|arctozolt
+,,,,80,55|arctozolt
 85|duraludon
+100,,,45,,|armaldo
+85|bombirdier
+92,,,,74,|flamigo
+85,78,,118,,|scovillain
+,65,,85,,|scream-tail
+85,89,,32,,|spidops
+78,,70,,,|tatsugiri
+,85,87,,,|tinkaton
+,115,,35,,|wugtrio
 
 |pikachu-belle|electric,ice
 |pikachu-phd|electric,psychic

--- a/patches/radred.txt
+++ b/patches/radred.txt
@@ -6,21 +6,21 @@ eternamax-orb|toxic-orb|If held by an Eternatus, this item triggers its Primal R
 
 --move
 # Modifications
-drill-peck|||Has an increased chance for a critical hit.
+drill-peck|||The beak acts as a drill, boasting high critical-hit ratio.
 triple-kick||20
-charge-beam|||Boosts the user's Special Attack by one stage
+charge-beam|||The user fires a load of electricity that may raise the user's Sp. Atk. 
 self-destruct||100|Target's Defense is halved during damage. User faints.
 explosion||100|Target's Defense is halved during damage. User faints.
 poison-fang||75
 shadow-claw||80
 parabolic-charge||75
 rock-smash||60
-kings-shield|||Protects from damaging attacks.
+kings-shield|||The user protects itself from damage, and changes the user's form if applicable.
 roar-of-time||80|Forces the target to switch to a random ally.
 ice-hammer|||No effect
-bleakwind-storm|||20% chance to inflict frostbite
-springtide-storm|||Cannot miss in rain
-chloroblast||150|50% recoil damage
+bleakwind-storm|||The foe is caught in a fierce cold wind that can cause frostbite. 20% chance to inflict frostbite.
+springtide-storm|||The foe is caught in a wind filled with love and hate. 30% chance to lower Attack. Cannot miss in rain.
+chloroblast||150|The user launches its amassed chloro- phyll to inflict damage. 50% recoil damage.
 dire-claw||80
 esper-wing||80|The user slashes the target with aura- enriched wings that raise Speed. It has a high crit ratio.
 hail|||A 5-turn snowstorm that boosts the Def of Ice-types by 50%.


### PR DESCRIPTION
Still a lot left to do for a complete update, but this should be a good starting point to get the tracker working for version 4.0.

Sadly I haven't been able to validate everything since the [Boss Editor](https://nuzlocke-builder.vercel.app/) doesn't seem to have feature parity with the nuzlocke app, so if anyone has any way to easily validate the data that would be swell.

Progress so far, in case anyone wants to pick up the ball.

**Normal**
- [x] Normal rival/rocket fights
- [x] Normal gyms
- [x] Normal E4
- [x] Normal rematches

**Hardcore**
- [ ] Hardcore rival/rocket fights
- [ ] Hardcore gyms
- [ ] Hardcore E4
- [ ] Hardcore rematches

**General**
- [x] Pokemon stats changes
- [x] Move changes
- [ ] Route changes